### PR TITLE
Fixed dashStyle param, as it should be a basestring

### DIFF
--- a/highcharts/highstock/common.py
+++ b/highcharts/highstock/common.py
@@ -655,7 +655,7 @@ class PlotBands(ArrayObject):
 class PlotLines(ArrayObject):
     ALLOWED_OPTIONS = {
     "color": (ColorObject, basestring, dict),
-    "dashStyle": int,
+    "dashStyle": basestring,
     "events": (Events, dict),
     "id": basestring,
     "label": (Labels, dict),


### PR DESCRIPTION
This was done for Highchart in https://github.com/kyper-data/python-highcharts/pull/35, but not for Highstock