### PR TITLE
Revert "Update JSsource urls to use Highcharts v6.x (#62)"

### DIFF
--- a/highcharts/highcharts/highcharts.py
+++ b/highcharts/highcharts/highcharts.py
@@ -68,11 +68,11 @@ class Highchart(object):
         # set Javascript src, Highcharts lib needs to make sure it's up to date
         self.JSsource = [
                 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
-                'https://code.highcharts.com/6/highcharts.js',
-                'https://code.highcharts.com/6/highcharts-more.js',
-                'https://code.highcharts.com/6/modules/heatmap.js',
-                'https://code.highcharts.com/6/modules/wordcloud.js',
-                'https://code.highcharts.com/6/modules/exporting.js'
+                'https://code.highcharts.com/highcharts.js',
+                'https://code.highcharts.com/highcharts-more.js',
+                'https://code.highcharts.com/modules/heatmap.js',
+                'https://code.highcharts.com/modules/wordcloud.js',
+                'https://code.highcharts.com/modules/exporting.js'
             ]
 
         # set CSS src

--- a/highcharts/highmaps/highmaps.py
+++ b/highcharts/highmaps/highmaps.py
@@ -66,11 +66,11 @@ class Highmap(object):
         # Set Javascript src
         self.JSsource = [
                 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
-                'https://code.highcharts.com/maps/6/highmaps.js',
-                'https://code.highcharts.com/6/highcharts.js',
-                'https://code.highcharts.com/maps/6/modules/map.js',
-                'https://code.highcharts.com/maps/6/modules/data.js',
-                'https://code.highcharts.com/maps/6/modules/exporting.js'
+                'https://code.highcharts.com/maps/highmaps.js',
+                'https://code.highcharts.com/highcharts.js',
+                'https://code.highcharts.com/maps/modules/map.js',
+                'https://code.highcharts.com/maps/modules/data.js',
+                'https://code.highcharts.com/maps/modules/exporting.js'
             ]
 
         # set CSS src

--- a/highcharts/highstock/highstock.py
+++ b/highcharts/highstock/highstock.py
@@ -63,9 +63,9 @@ class Highstock(object):
         # set Javascript src, Highcharts lib needs to make sure it's up to date
         self.JSsource = [
                 'https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js',
-                'https://code.highcharts.com/stock/6/highstock.js',
-                'https://code.highcharts.com/stock/6/modules/exporting.js',
-                'https://code.highcharts.com/6/highcharts-more.js',
+                'https://code.highcharts.com/stock/highstock.js',
+                'https://code.highcharts.com/stock/modules/exporting.js',
+                'https://code.highcharts.com/highcharts-more.js',
             ]
 
         # set CSS src


### PR DESCRIPTION
This reverts commit af7e4f8183a6c2a82303876c97dcf4aab2186daf.

No longer needed, issue was fixed in Highcharts 7.0.1.