### PR TITLE
Workaround slow initial rendering of highchart/highstock

### DIFF
--- a/highcharts/highcharts/templates/content.html
+++ b/highcharts/highcharts/templates/content.html
@@ -34,7 +34,7 @@
 
             $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
             {
-                chart.addSeries({{chart.data_list[loop.index0]}});
+                chart.addSeries({{chart.data_list[loop.index0]}}, false);
             });
 
           {% endfor %}
@@ -42,9 +42,10 @@
             var data = {{chart.data}};
             var dataLen = data.length;
             for (var ix = 0; ix < dataLen; ix++) {
-                chart.addSeries(data[ix]);
+                chart.addSeries(data[ix], false);
             }
         {% endif %} 
+        chart.redraw();
 
 
         {% if chart.jscript_end_flag %}

--- a/highcharts/highstock/templates/content.html
+++ b/highcharts/highstock/templates/content.html
@@ -31,7 +31,7 @@
 
             $.getJSON({{data_url}}, function ({{chart.jsonp_data}})
             {
-                chart.addSeries({{chart.data_list[loop.index0]}});
+                chart.addSeries({{chart.data_list[loop.index0]}}, false);
             });
 
           {% endfor %}
@@ -40,10 +40,11 @@
             var data = {{chart.data}};
             var dataLen = data.length;
             for (var ix = 0; ix < dataLen; ix++) {
-                chart.addSeries(data[ix]);
+                chart.addSeries(data[ix], false);
             }
 
         {% endif %} 
+        chart.redraw();
 
 {% endblock body_content %}
 


### PR DESCRIPTION
highcharts specifically recommends against using `addSeries` for initial
rendering:

"Note that this method should **_never_** be used when adding data
synchronously at chart render time"

Disabling redraw and then manually redrawing afterwards at least
solves part of the problem.